### PR TITLE
fix: updated Getting app log doc by providing official link

### DIFF
--- a/android/Getting-app-logs-from-Android-Studio.md
+++ b/android/Getting-app-logs-from-Android-Studio.md
@@ -5,10 +5,4 @@ Brief walkthrough for users on how to post logs if they are encountering issues.
 1. On your computer, [download](https://developer.android.com/studio/) and [install](https://developer.android.com/studio/install) Android Studio
 2. On your phone, [enable developer options and USB debugging](https://developer.android.com/studio/debug/dev-options#enable)
 3. Connect your phone to your computer with a USB cable
-4. Open Android Studio, and click `Android Device Monitor`
-![android_device_monitor_1](https://user-images.githubusercontent.com/3611199/27092050-6bba06c2-50a5-11e7-9123-909d6fdc52ac.png)
-5. In Android Device Monitor, click on the name of your phone.
-6. In the text field in the middle of Android Device Monitor, set the drop down menu on the right to "debug"
-![android device monitor](https://user-images.githubusercontent.com/3611199/27092086-8dbc3c86-50a5-11e7-9b1e-91f1f675ec72.png)
-7. On your phone, open the Commons app and perform whatever action you are having problems with in the app
-9. Copy all of the logs from Android Device Monitor (in the box on the bottom right) and paste them into an issue report on [Github](https://github.com/commons-app/apps-android-commons/issues/new), along with a description of the problem you are having.
+4. Refer this link to view the logs: [official link](https://developer.android.com/studio/debug/am-logcat#running).


### PR DESCRIPTION
Fixes: #15 
Updated the Getting app logs from Android Studio by providing a link of the official Android Doc which makes it easier for the user to follow as there are correct guidelines given in the website along with screenshots.

https://github.com/Bhavnaharitsa/commons-app-documentation/blob/logs_update/android/Getting-app-logs-from-Android-Studio.md