### PR TITLE
fix:  resized images into table of Tutorial-to-new-users

### DIFF
--- a/android/Tutorial-for-new-users.md
+++ b/android/Tutorial-for-new-users.md
@@ -5,31 +5,26 @@
 Tutorial and app released under Apache 2.0 license. 
 New pictures in tutorial taken by Nicolas Raoul and Josephine Lim, and released under Public Domain license.
 
-**Page 1**
+Page 1 | Page 2
+|:---:|:---:|
+![tutorial-1](https://cloud.githubusercontent.com/assets/3611199/20912096/0765f68a-bbd2-11e6-85ce-898e29a3b7e5.png) | ![tutorial-2](https://cloud.githubusercontent.com/assets/3611199/20912097/0939059c-bbd2-11e6-9980-266b33df303e.png)
 
-![tutorial-1](https://cloud.githubusercontent.com/assets/3611199/20912096/0765f68a-bbd2-11e6-85ce-898e29a3b7e5.png)
+Page 3 | Page 4
+|:---:|:---:|
+![tutorial-3](https://cloud.githubusercontent.com/assets/3611199/20912098/0ae532c6-bbd2-11e6-8545-5f4bfa42ee47.png) | ![tutorial-4](https://cloud.githubusercontent.com/assets/3611199/20912100/1077730c-bbd2-11e6-9b14-ad737be1ca80.png)
 
-**Page 2**
-
-![tutorial-2](https://cloud.githubusercontent.com/assets/3611199/20912097/0939059c-bbd2-11e6-9980-266b33df303e.png)
-
-**Page 3**
-
-![tutorial-3](https://cloud.githubusercontent.com/assets/3611199/20912098/0ae532c6-bbd2-11e6-8545-5f4bfa42ee47.png)
-
-**Page 4**
-
-![tutorial-4](https://cloud.githubusercontent.com/assets/3611199/20912100/1077730c-bbd2-11e6-9b14-ad737be1ca80.png)
-
-**Page 5**
-
+Page 5
+|:---:|
 ![tutorial-5](https://cloud.githubusercontent.com/assets/3611199/20912110/175ddd14-bbd2-11e6-91be-705cbba96e3c.png)
 
 
 ***
 
 ## Screenshots of the original/old tutorial:
-
-![existing-tutorial-1](https://cloud.githubusercontent.com/assets/3611199/20377868/514d80b8-acf7-11e6-9785-9ac9bba53041.png)
-![existing-tutorial-2](https://cloud.githubusercontent.com/assets/3611199/20377869/5443a554-acf7-11e6-966c-40207559c675.png)
+Tutorial 1 | Tutorial 2
+|:---:|:---:|
+![existing-tutorial-1](https://cloud.githubusercontent.com/assets/3611199/20377868/514d80b8-acf7-11e6-9785-9ac9bba53041.png) | ![existing-tutorial-2](https://cloud.githubusercontent.com/assets/3611199/20377869/5443a554-acf7-11e6-966c-40207559c675.png)
+Tutorial 3
 ![existing-tutorial-3](https://cloud.githubusercontent.com/assets/3611199/20377874/592d17d0-acf7-11e6-9139-c0872860da5a.png)
+
+


### PR DESCRIPTION
Fixes: #19 
Resized the images in Tutorial-to-new-users into tables 
Output: https://github.com/Bhavnaharitsa/commons-app-documentation/blob/resize_image/android/Tutorial-for-new-users.md

Please review @domdomegg @maskaravivek @macgills @misaochan 