### PR TITLE
Project-maintenance: add more details that were missing

### DIFF
--- a/android/Project-maintenance.md
+++ b/android/Project-maintenance.md
@@ -6,15 +6,32 @@ See [Developer workflow](Developer-workflow.md)
 
 # Procedure to release a new version
 
+## Before release
+
+Before proceeding to do the steps necessary for publishing a release, make sure you **build the `prodRelease` variant of the app** from the code you plan on using for the release. If that build works fine, you could proceed with the steps to release the version.
+
+This is particularly necessary if the change touches any model classes as ProGuard would kick in and trim them if [our rules]([url](https://github.com/commons-app/apps-android-commons/blob/main/app/proguard-rules.txt#L35-L41)) are not appropriate.
+
+## Generate release build after verification
+
 1. Add the new features to [CHANGELOG.md](https://github.com/commons-app/apps-android-commons/blob/master/CHANGELOG.md)
 1. Increment `versionCode` and `versionName` in [app/build.gradle](https://github.com/commons-app/apps-android-commons/blob/master/app/build.gradle)
 1. Commit, and push to Github
-1. Tag the commit as `v` + the version number, for instance `v1.32` for version 1.32. This is needed [for F-Droid](https://gitlab.com/fdroid/fdroiddata/blob/master/metadata/fr.free.nrw.commons.txt). Don't forget to push the tags (`git push commons-app --tags`).
-1. Replace throw-away Mapbox token with actual production token that is kept privately. Reach out to Nicolas / Sivaraam to get the token.
+1. Tag the commit as `v` + the version number, for instance `v1.32` for version 1.32. This is needed [for F-Droid](https://gitlab.com/fdroid/fdroiddata/blob/master/metadata/fr.free.nrw.commons.txt) (`git tag v1.32`). Don't forget to push the tags (`git push --tags`).
 1. Generate the signed app bundle using the keystore via the **Build > Generate Signed Bundle / APK** menu [[ref](https://developer.android.com/studio/publish/app-signing#sign-apk)]
-1. Click 'Draft a new release' and fill in details
-1. Publish to Google Play
-1. Update Google Play's changelog
+    - Note: In this step, we need to generate an APK not an Android App bundle.
+
+## Publish 'Open testing' release
+
+1. Once the production APK is ready, go to the Google Play Console and switch to the **Testing > Open Testing** page.
+1. Click 'Create new release' and upload the production APK.
+1. Make sure to attach the ReTrace mapping file located at `app/build/outputs/mapping/prodRelease/mapping.txt` to the uploaded APK. This is possible through the overflow menu seen near the uploaded APK.
+1. Fill in the changelog and verify rollout information.
+1. After verification is done, rollout the release for testing.
+
+## Promoting the test release to production
+
+TODO
 
 # Branching and hotfix system for releases
 


### PR DESCRIPTION
Add new release related information that was missing in the current document. Further, include the information about the need to check the production APK before tagging the code due to ProGuard trimming causing issues.

I'm yet to add instructions about promoting the test version to production. Will do so soon once I promote the latest release. Marking this as draft until that,