### PR TITLE
Update Quick Start Guide to Fix Setup Issues and Improve Clarity #37

### DIFF
--- a/API/leaderboard.md
+++ b/API/leaderboard.md
@@ -1,125 +1,130 @@
-# Leaderboard API
+# Wikimedia Commons Android App Leaderboard API
 
-This API is used to fetch leaderboard list and add a new user to leaderboard if does not exists.
+This API retrieves the leaderboard for the Wikimedia Commons Android App and allows adding a new user to the leaderboard if they do not already exist.
 
 ## Base URL
-`https://tools.wmflabs.org/commons-android-app/tool-commons-android-app`
-
+[https://tools.wmflabs.org/commons-android-app/tool-commons-android-app](https://tools.wmflabs.org/commons-android-app/tool-commons-android-app)
 ## Endpoint
 `/leaderboard.py`
 
-## Request Type
+## Request Method
 `GET`
 
-## Response Type
+## Response Format
 `JSON`
 
 ## Required Parameters
+The following parameters must be included in every request:
 
-- **user** - This is username of the user, for example **Syced** (if username has **whitespaces** then replace them with `_` )
+| Parameter  | Description                                                                 | Valid Values                     |
+|------------|-----------------------------------------------------------------------------|----------------------------------|
+| `user`     | The username of the user. Replace any spaces in the username with underscores (`_`). | Example: `Syced`                 |
+| `duration` | The time period for the leaderboard data.                                   | `all_time`, `weekly`, `yearly`   |
+| `category` | The type of contribution to rank.                                           | `upload`, `used`, `nearby`       |
 
-- **duration** - Can be **all_time** or **weekly** or **yearly**
+**Note**: If the specified `user` is not already on the leaderboard, they will be added during the first request. This process may cause a slight delay in the response.
 
-- **category** - Can be **upload** or **used** or **nearby**
+## Optional Parameters
+The following parameters are optional and can be included as needed:
 
-Note: If username is not already added to leaderboard then it would be added in the first request and this request may take extra time to generate response.
+| Parameter  | Description                                                                 | Default Value                                                                 |
+|------------|-----------------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| `avatar`   | A custom image URL for the user’s avatar. Only used when adding a new user to the leaderboard. | [https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png](https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png) |
+| `limit`    | The maximum number of leaderboard entries to return. Must be used with `offset`. | None                                                                          |
+| `offset`   | The starting point for the leaderboard entries. Must be used with `limit`.   | None                                                                          |
 
-## Optional Paramaters
-
-- **avatar** - This should be only used if a new user needs to be added to the leaderboard and wants a custom avatar, should be complete Image URL for example `https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png` If no **avatar** is supplied then default one would be used i.e. **https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png**
-
-- **limit** - This is the limit for the number of results and should be passed along with offset, for example **5**
-
-- **offset** - This is the offset for the results and should be passed along with limit, for example **1**
+**Example Avatar URL**: [https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png](https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png)
 
 ## Example Request
-
-```
+```bash
 curl --location --request GET 'https://tools.wmflabs.org/commons-android-app/tool-commons-android-app/leaderboard.py?user=Syced&duration=all_time&category=used'
 ```
 
 ## Example Response
-
-```
+```bash
 {
-    "status": 200,
-    "username": "Syced",
-    "category_count": 462,
-    "limit": null,
-    "avatar": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png",
-    "offset": null,
-    "duration": "all_time",
-    "leaderboard_list": [
-        {
-            "username": "Fæ",
-            "category_count": 107147,
-            "avatar": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png",
-            "rank": 1
-        },
-        {
-            "username": "JAn Dudík",
-            "category_count": 912,
-            "avatar": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png",
-            "rank": 2
-        },
-        {
-            "username": "Vojtěch Dostál",
-            "category_count": 749,
-            "avatar": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png",
-            "rank": 3
-        },
-        {
-            "username": "Syced",
-            "category_count": 462,
-            "avatar": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png",
-            "rank": 4
-        },
-        {
-            "username": "Misaochan",
-            "category_count": 101,
-            "avatar": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png",
-            "rank": 5
-        },
-        {
-            "username": "Kookaburra 81",
-            "category_count": 41,
-            "avatar": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png",
-            "rank": 6
-        },
-        {
-            "username": "Madhurgupta10",
-            "category_count": 1,
-            "avatar": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png",
-            "rank": 7
-        },
-        {
-            "username": "Macgills2",
-            "category_count": 1,
-            "avatar": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png",
-            "rank": 8
-        }
-    ],
-    "category": "used",
-    "rank": 4
+  "status": 200,
+  "username": "Syced",
+  "category_count": 462,
+  "limit": null,
+  "avatar": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png",
+  "offset": null,
+  "duration": "all_time",
+  "leaderboard_list": [
+    {
+      "username": "Fæ",
+      "category_count": 107147,
+      "avatar": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png",
+      "rank": 1
+    },
+    {
+      "username": "JAn_Dudík",
+      "category_count": 912,
+      "avatar": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png",
+      "rank": 2
+    },
+    {
+      "username": "Vojtěch_Dostál",
+      "category_count": 749,
+      "avatar": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png",
+      "rank": 3
+    },
+    {
+      "username": "Syced",
+      "category_count": 462,
+      "avatar": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png",
+      "rank": 4
+    },
+    {
+      "username": "Misaochan",
+      "category_count": 101,
+      "avatar": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png",
+      "rank": 5
+    },
+    {
+      "username": "Kookaburra_81",
+      "category_count": 41,
+      "avatar": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png",
+      "rank": 6
+    },
+    {
+      "username": "Madhurgupta10",
+      "category_count": 1,
+      "avatar": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png",
+      "rank": 7
+    },
+    {
+      "username": "Macgills2",
+      "category_count": 1,
+      "avatar": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png",
+      "rank": 8
+    }
+  ],
+  "category": "used",
+  "rank": 4
 }
 ```
+## Error Responses
+The API may return the following error responses:
 
-## Example Error Responses
-
-**Missing Parameters**
-```
+### Missing Parameters
+```bash
 {
-    "status": "400",
-    "message": "Invalid Parameters",
-    "user": null
+  "status": 400,
+  "message": "Invalid Parameters",
+  "user": null
 }
 ```
-
-**Invalid Username**
-```
+### Invalid Username
+```bash
 {
-    "status": "500",
-    "message": "Internal Server Error",
-    "user": "asdasdad1a5sd1a61s5d1a"
+  "status": 500,
+  "message": "Internal Server Error",
+  "user": "asdasdad1a5sd1a61s5d1a"
 }
 ```
+## Notes
+- Ensure the `user` parameter replaces spaces with underscores (e.g., `John Doe` becomes `John_Doe`).
+- The `avatar` parameter is only applied when a new user is added to the leaderboard. If no avatar is provided, the default avatar URL is used.
+- Use the `limit` and `offset` parameters together to paginate leaderboard results.
+- For issues or questions, consult the Wikimedia Commons *Help desk* or *Village pump/Technical* at [https://commons.wikimedia.org](https://commons.wikimedia.org).

--- a/API/leaderboard.md
+++ b/API/leaderboard.md
@@ -58,13 +58,13 @@ curl --location --request GET 'https://tools.wmflabs.org/commons-android-app/too
       "rank": 1
     },
     {
-      "username": "JAn_Dudík",
+      "username": "JAn Dudík",
       "category_count": 912,
       "avatar": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png",
       "rank": 2
     },
     {
-      "username": "Vojtěch_Dostál",
+      "username": "Vojtěch Dostál",
       "category_count": 749,
       "avatar": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png",
       "rank": 3
@@ -82,7 +82,7 @@ curl --location --request GET 'https://tools.wmflabs.org/commons-android-app/too
       "rank": 5
     },
     {
-      "username": "Kookaburra_81",
+      "username": "Kookaburra 81",
       "category_count": 41,
       "avatar": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Gnome-stock_person.svg/200px-Gnome-stock_person.svg.png",
       "rank": 6

--- a/API/leaderboard.md
+++ b/API/leaderboard.md
@@ -18,7 +18,7 @@ The following parameters must be included in every request:
 
 | Parameter  | Description                                                                 | Valid Values                     |
 |------------|-----------------------------------------------------------------------------|----------------------------------|
-| `user`     | The username of the user. Replace any spaces in the username with underscores (`_`). | Example: `Syced`                 |
+| `user`     | The username of the user. | Example: `Syced`                 |
 | `duration` | The time period for the leaderboard data.                                   | `all_time`, `weekly`, `yearly`   |
 | `category` | The type of contribution to rank.                                           | `upload`, `used`, `nearby`       |
 
@@ -43,7 +43,7 @@ curl --location --request GET 'https://tools.wmflabs.org/commons-android-app/too
 ## Example Response
 ```bash
 {
-  "status": 200,
+  "status": "200",
   "username": "Syced",
   "category_count": 462,
   "limit": null,
@@ -123,8 +123,3 @@ The API may return the following error responses:
   "user": "asdasdad1a5sd1a61s5d1a"
 }
 ```
-## Notes
-- Ensure the `user` parameter replaces spaces with underscores (e.g., `John Doe` becomes `John_Doe`).
-- The `avatar` parameter is only applied when a new user is added to the leaderboard. If no avatar is provided, the default avatar URL is used.
-- Use the `limit` and `offset` parameters together to paginate leaderboard results.
-- For issues or questions, consult the Wikimedia Commons *Help desk* or *Village pump/Technical* at [https://commons.wikimedia.org](https://commons.wikimedia.org).

--- a/API/leaderboard.md
+++ b/API/leaderboard.md
@@ -110,7 +110,7 @@ The API may return the following error responses:
 ### Missing Parameters
 ```bash
 {
-  "status": 400,
+  "status": "400",
   "message": "Invalid Parameters",
   "user": null
 }
@@ -118,7 +118,7 @@ The API may return the following error responses:
 ### Invalid Username
 ```bash
 {
-  "status": 500,
+  "status": "500",
   "message": "Internal Server Error",
   "user": "asdasdad1a5sd1a61s5d1a"
 }

--- a/android/Quick-start-guide-for-Developers.md
+++ b/android/Quick-start-guide-for-Developers.md
@@ -1,48 +1,147 @@
-# Quick start guide for Developers
 
-1. [Download and Install Android Studio][1]
+# Quick Start Guide for Developers
 
-2. Fork the Git repository.
-    - Go to [the main Github repo](https://github.com/commons-app/apps-android-commons/) and click "Fork".
+This guide provides step-by-step instructions to set up the Commons App development environment using Android Studio. It includes solutions to common setup issues to ensure a smooth onboarding experience.
 
-3. Clone your fork to your local machine.
-    - Click "Clone" on your fork's Github page, and copy the Git URL. It should look like:<br>`git@github.com:yourname/apps-android-commons.git`
+## Prerequisites
 
-4. Open the project in Android Studio.
-    - Open Android Studio
-    - In the menu bar, click `File` > `New` > `Project from Version Control...` > `Git`<br>
-    OR<br>
-    (if Quick Start menu open): `Get from Version Control` > `Git`
-    - Enter the Git URL you obtained in step 3.
-    - Specify a local directory you would like to save the project in and select `OK`.
+Before starting, ensure the following tools are installed and configured:
 
-5. Start contributing! Be sure to read through the [developer workflow](Developer-workflow.md) and the [code style guide](Code-style.md).
+- **Git**: Install Git and add it to your system's PATH environment variable. Verify with `git --version` in your terminal. [Download Git](https://git-scm.com/downloads).
+- **Android Studio**: Download and install the latest version of Android Studio. [Download Android Studio](https://developer.android.com/studio/).
+- **Java Development Kit (JDK)**: Use JDK 11 for compatibility with the Commons App. Verify with `java -version`. [Download JDK 11](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html).
+- **Android SDK**: Ensure the required SDK components are installed (detailed in the setup steps below).
 
-## Building the source code
+After installing Git or updating the PATH, restart your machine to apply changes.
 
-You can build the `beta` and `prod` flavor of the app for `debug` build type using the Android Studio. Read up more about flavors and build types [here](https://developer.android.com/studio/build/build-variants). Several features are not usable with the `beta` flavor. The only advantage of the beta flavor is that you can do test modifications and upload test pictures without getting banned. Please do not upload any copyrighted picture though, you would get banned even on the beta environment.
+## Setting Up the Development Environment
 
-You can either directly invoke the following commands using your terminal or you can [edit configurations](https://developer.android.com/studio/run/rundebugconfig) in android studio and add these configs. 
-To build the `beta` `debug` variant use: 
+### 1. Fork the Git Repository
 
+- Navigate to the [Commons App repository](https://github.com/commons-app/apps-android-commons/) on GitHub.
+- Click the "Fork" button to create a copy of the repository under your GitHub account.
+
+### 2. Clone Your Fork
+
+- On your fork’s GitHub page, click the "Code" button and copy the Git URL (e.g., `git@github.com:yourname/apps-android-commons.git`).
+- Open a terminal and clone the repository to your local machine:
+
+```bash
+git clone git@github.com:yourname/apps-android-commons.git
+cd apps-android-commons
 ```
-:app:installBetaDebug
-``` 
 
-To build the `prod` `debug` variant use: 
+### 3. Open the Project in Android Studio
 
+- Launch Android Studio.
+- Select File > New > Project from Version Control... > Git (or from the Quick Start menu, choose Get from Version Control > Git).
+- Paste the Git URL copied in step 2.
+- Specify a local directory for the project and click OK.
+
+### 4. Configure Android SDK Components
+
+To avoid common build errors, install the required SDK components:
+
+- Open Android Studio and navigate to **File > Settings** (or **Android Studio > Preferences** on macOS) > **Appearance & Behavior > System Settings > Android SDK**.
+- Select the **SDK Platforms** tab:
+  - Check **Show Package Details**.
+  - Under **Android 9.0 (Pie)**, select **Android SDK Platform 28**.
+- Select the **SDK Tools** tab:
+  - Check **Show Package Details**.
+  - Under **Android SDK Build-Tools**, select version **29.0.2**.
+  - Under **NDK (Side by side)**, select version **21.0.6113669**.
+- Click **Apply** to install the selected components, then click **Finish**.
+
+### 5. Verify JDK Configuration
+
+Ensure Android Studio is using JDK 11:
+
+- Go to **File > Project Structure > SDK Location**.
+- Under **JDK**, select the JDK 11 installation or click **Download JDK** to install it.
+
+If you encounter issues related to Kotlin compilation (e.g., `kaptBetaDebugKotlin` errors), verify that the **Gradle JDK** is set to version 11:
+
+- Go to **File > Settings > Build, Execution, Deployment > Build Tools > Gradle**.
+- Set **Gradle JVM** to **JDK 11**.
+
+## Start Contributing
+
+- Read the **Developer Workflow** and **Code Style Guide** to understand contribution guidelines and coding standards.
+- Begin making changes to the codebase or documentation as needed.
+
+## Building the Source Code
+
+The Commons App supports two flavors (beta and prod) and two build types (debug and release). The **beta** flavor is recommended for testing, as it allows test modifications and uploads without risking a ban. However, **do not upload copyrighted
+images**, even in the beta environment.
+
+### Building with Android Studio
+
+- Open the **Build Variants** panel in Android Studio (usually at the bottom left).
+- Select the desired variant: `betaDebug` or `prodDebug`.
+- Click **Run** to build and install the app on a connected device or emulator.
+
+### Building via Terminal
+
+You can build and install the app using Gradle commands:
+
+For the beta debug variant:
+
+```bash
+./gradlew :app:installBetaDebug
 ```
-:app:installProdDebug
-``` 
 
-Note: 
+For the prod debug variant:
 
-- You can also build and test the `release` variant for both `beta` and `prod` but you would need to use your own signing keys for it. Read up more about signing keys [here](https://developer.android.com/studio/publish/app-signing). Building and testing `release` variant might be required when you are debugging an issue that is happening just on `release` builds and not on `debug` builds. Most likely it should be a proguard issue. 
+```bash
+./gradlew :app:installProdDebug
+```
 
-## Frequent issues
+Alternatively, configure these commands in Android Studio:
 
-- **Issue:** `Cannot run program "git" (in directory "<project path>"): CreateProcess error=2, The system cannot find the file specified`<br>
-    **Fix:** Make sure git is installed and added in the PATH environment variable. Don't forget to restart the machine after updating your PATH environment variable.
+- Go to **Run > Edit Configurations**.
+- Add a new **Gradle** configuration with the above commands.
+
+### Notes on Release Builds
+
+- To build the release variant for beta or prod, you need signing keys. See Android’s App Signing Guide for details.
+- Use release builds only when debugging issues specific to release configurations (e.g., ProGuard-related issues).
+
+## Troubleshooting Common Issues
+
+### Issue: Cannot run program "git"
+
+**Fix**: Ensure Git is installed and added to the PATH environment variable. Verify with `git --version`. Restart your machine after updating PATH.
+
+### Issue: No mapping for: android/support/FILE_PROVIDER_PATHS
+
+**Fix**: Install Android SDK Build-Tools 29.0.2, Android SDK Platform 28, and NDK 21.0.6113669 as described in step 4 of the setup process.
+
+### Issue: Failed to find Build Tools revision 29.0.2
+
+**Fix**: Install Android SDK Build-Tools 29.0.2 via **Settings > Android SDK > SDK Tools**.
+
+### Issue: Failed to find Platform SDK with path: platforms;android-28
+
+**Fix**: Install Android SDK Platform 28 via **Settings > Android SDK > SDK Platforms**.
+
+### Issue: Missing NDK version 21.0.6113669
+
+**Fix**: Install NDK 21.0.6113669 via **Settings > Android SDK > SDK Tools**.
+
+### Issue: Execution failed for task ':app:kaptBetaDebugKotlin'
+
+**Fix**:
+
+- Ensure JDK 11 is used in Project Structure and Gradle JVM settings.
+- Sync the project with Gradle: **File > Sync Project with Gradle Files**.
+- Clean and rebuild the project:
+
+```bash
+./gradlew clean
+./gradlew build
+```
+
+If the issue persists, check for outdated dependencies in `build.gradle`. Update Kotlin and other plugins to compatible versions (consult the repository’s `build.gradle` for specific versions).
 
 Did you run into other problems? Please add any issue which is not captured here along with its fix. If you don't have edit permissions, submit a [new issue](https://github.com/commons-app/apps-android-commons/issues/new).
 


### PR DESCRIPTION
Closes #37 

Updated `quick-start-guide-for-developers.md` to address setup issues reported in #37 , including:
- Added instructions for installing Android SDK Build-Tools 29.0.2, SDK Platform 28, and NDK 21.0.6113669.
- Included fix for `kaptBetaDebugKotlin` error with JDK 11 and Gradle sync.
- Improved clarity and structure of setup, build, and troubleshooting sections.
- Added prerequisites and contribution guidelines for better onboarding.

Please review and let me know if any changes are needed.